### PR TITLE
Fixed the usage of SerialPort

### DIFF
--- a/src/arduino-firmata.coffee
+++ b/src/arduino-firmata.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
 events = require 'eventemitter2'
-{SerialPort} = serialport = require 'serialport'
+serialport = require 'serialport'
 
 debug = require('debug')('arduino-firmata')
 
@@ -42,6 +42,7 @@ exports = module.exports = class ArduinoFirmata extends events.EventEmitter2
       callback null, devices
 
   constructor: ->
+    super()
     @status = ArduinoFirmata.Status.CLOSE
     @wait_for_data = 0
     @execute_multi_byte_command = 0
@@ -57,7 +58,7 @@ exports = module.exports = class ArduinoFirmata extends events.EventEmitter2
   isOldArduinoDevice: ->
     return /usbserial|USB/.test @serialport_name
 
-  connect: (@serialport_name, opts={baudrate: 57600}) ->
+  connect: (@serialport_name, opts={baudRate: 57600}) ->
     opts.parser = serialport.parsers.raw
     unless @serialport_name
       ArduinoFirmata.list (err, devices) =>
@@ -82,7 +83,7 @@ exports = module.exports = class ArduinoFirmata extends events.EventEmitter2
         @emit 'connect'
       , io_init_wait
 
-    @serialport = new SerialPort @serialport_name, opts
+    @serialport = new serialport @serialport_name, opts
     @serialport.once 'open', =>
       cid = setInterval =>
         debug 'request REPORT_VERSION'

--- a/tests/test_arduino.coffee
+++ b/tests/test_arduino.coffee
@@ -16,10 +16,9 @@ describe 'class ArduinoFirmata', ->
 
   describe 'method list', ->
 
-    it 'should return list of serialports', (done) ->
+    it 'should return list of serialports', ->
       ArduinoFirmata.list (err, devices) ->
-        assert.equal devices instanceof Array, true
-        done()
+        assert.equal (devices instanceof Array), true
 
 
 describe 'instance of ArduinoFirmata', ->


### PR DESCRIPTION
SerialPort library seems to have changed from the convention used in the source at version `4.0.0`:
Requiring `serialport` now returns the `SerialPort` constructor function instead of a factory object. `SerialPort.SerialPort` is now deprecated.
